### PR TITLE
Add CSV Format search/replace to Search & Replace Tab

### DIFF
--- a/inc/Database/Exporter.php
+++ b/inc/Database/Exporter.php
@@ -325,6 +325,8 @@ class Exporter {
 					$table_report[ 'rows' ] ++;
 
 					foreach ( $row as $column => $value ) {
+						//Skip the GUID column per Wordpress Codex
+						
 						//if "change database prefix" is set we have to look for occurrences of the old prefix in the db entries and change them
 						if ( $new_table !== $table ) {
 							$value = $this->replace->recursive_unserialize_replace(
@@ -335,7 +337,7 @@ class Exporter {
 						//skip replace if no search pattern
 						//check if we need to replace something
 						//skip primary_key
-						if ( $search !== '' && $column !== $primary_key ) {
+						if ( $search !== '' && $column !== $primary_key && $column !== "guid") {
 
 							$edited_data = $this->replace->recursive_unserialize_replace(
 								$search, $replace,

--- a/inc/Database/Exporter.php
+++ b/inc/Database/Exporter.php
@@ -301,7 +301,15 @@ class Exporter {
 
 		$page_size = $this->page_size;
 		$pages     = ceil( $row_count / $page_size );
-
+		//Prepare CSV data
+		if($csv != null) {
+			$csv_lines = explode("\n", $csv);
+			$csv_head = str_getcsv("search,replace");
+			$csv_array = array();
+			foreach ($csv_lines as $line) {
+				$csv_array[] = array_combine($csv_head, str_getcsv($line));
+			}
+		}
 		for ( $page = 0; $page < $pages; $page ++ ) {
 			$start = $page * $page_size;
 
@@ -333,7 +341,11 @@ class Exporter {
 								$search, $replace,
 								$value
 							);
-
+							if($csv != null) {
+								foreach($csv_array as $entry) {
+									$edited_data = $this->recursive_unserialize_replace( $entry['search'], $entry['replace'], $edited_data );
+								}
+							}
 							// Something was changed
 							if ( $edited_data !== $value ) {
 

--- a/inc/Database/Exporter.php
+++ b/inc/Database/Exporter.php
@@ -77,7 +77,7 @@ class Exporter {
 	 *                          $report[ 'errors'] : WP_Error_object,
 	 * $report ['changes'] : Array with replacements in tables
 	 */
-	public function db_backup( $search = '', $replace = '', $tables = array(), $domain_replace = FALSE, $new_table_prefix = '' ) {
+	public function db_backup( $search = '', $replace = '', $tables = array(), $domain_replace = FALSE, $new_table_prefix = '', $csv = null ) {
 
 		if ( count( $tables ) < 1 ) {
 			$tables = $this->dbm->get_tables();
@@ -158,7 +158,7 @@ class Exporter {
 				);
 
 			} else {
-				$table_report = $this->backup_table( $search, $replace, $table, $new_table_prefix );
+				$table_report = $this->backup_table( $search, $replace, $table, $new_table_prefix, $csv );
 			}
 			//log changes if any
 
@@ -195,7 +195,7 @@ class Exporter {
 	 * @return array $table_report Reports the changes made to the db.
 	 */
 
-	public function backup_table( $search = '', $replace = '', $table, $new_table_prefix = '' ) {
+	public function backup_table( $search = '', $replace = '', $table, $new_table_prefix = '', $csv = null ) {
 
 		$table_report = array(
 			'table_name' => $table,

--- a/inc/Database/Replace.php
+++ b/inc/Database/Replace.php
@@ -175,7 +175,10 @@ class Replace {
 				$update     = FALSE;
 
 				foreach ( $columns as $column ) {
-
+					//Skip the GUID column per Wordpress Codex
+					if($column == "guid") {
+						continue;
+					}
 					$data_to_fix = $row[ $column ];
 
 					if ( $column === $primary_key ) {

--- a/inc/Page/SearchReplace.php
+++ b/inc/Page/SearchReplace.php
@@ -301,5 +301,20 @@ class SearchReplace extends AbstractPage implements PageInterface {
 		}
 
 	}
+	
+	/**
+	 * shows the csv value in template
+	 */
+	private function get_csv_value() {
+
+		$csv = isset( $_POST[ 'csv' ] ) ? $_POST[ 'csv' ] : '';
+		$dry_run = isset( $_POST[ 'dry_run' ] ) ? TRUE : FALSE;
+		if ( $dry_run ) {
+			$csv = stripslashes( $csv );
+			$csv = htmlentities( $csv );
+			echo $csv;
+		}
+		
+	}
 
 }

--- a/inc/Page/SearchReplace.php
+++ b/inc/Page/SearchReplace.php
@@ -133,10 +133,10 @@ class SearchReplace extends AbstractPage implements PageInterface {
 		//remove wp_magic_quotes
 		$search  = stripslashes( filter_input( INPUT_POST, 'search' ) );
 		$replace = stripslashes( filter_input( INPUT_POST, 'replace' ) );
-
+		$csv	 = stripslashes( filter_input( INPUT_POST, 'csv' ) );
 		//if dry run is checked we run the replace function with dry run and return
 		if ( TRUE === $dry_run ) {
-			$this->run_replace( $search, $replace, $tables, $dry_run );
+			$this->run_replace( $search, $replace, $tables, $dry_run, $csv );
 
 			return FALSE;
 		}
@@ -145,11 +145,11 @@ class SearchReplace extends AbstractPage implements PageInterface {
 
 		if ( 'export' === $export_or_save ) {
 			//'export'-button was checked
-			$report = $this->dbe->db_backup( $search, $replace, $tables );
+			$report = $this->dbe->db_backup( $search, $replace, $tables, FALSE, '', $csv );
 			$this->downloader->show_modal( $report );
 		} else {
 			//"Save changes to database" was checked
-			$this->run_replace( $search, $replace, $tables, $dry_run );
+			$this->run_replace( $search, $replace, $tables, $dry_run, $csv );
 		}
 		
 		return TRUE;
@@ -173,7 +173,7 @@ class SearchReplace extends AbstractPage implements PageInterface {
 	 *
 	 * @return null
 	 */
-	protected function run_replace( $search, $replace, $tables, $dry_run ) {
+	protected function run_replace( $search, $replace, $tables, $dry_run, $csv = null ) {
 
 		echo '<div class="updated notice is-dismissible">';
 		if ( $dry_run ) {
@@ -194,7 +194,7 @@ class SearchReplace extends AbstractPage implements PageInterface {
 		}
 		$this->replace->set_dry_run( $dry_run );
 
-		$report = $this->replace->run_search_replace( $search, $replace, $tables );
+		$report = $this->replace->run_search_replace( $search, $replace, $tables, $csv );
 
 		if ( is_wp_error( $report ) ) {
 			$this->add_error( __( $report->get_error_message(), 'search-and-replace' ) );
@@ -233,7 +233,7 @@ class SearchReplace extends AbstractPage implements PageInterface {
 		$replace = filter_input( INPUT_POST, 'replace' );
 
 		//if search field is empty and replace field is not empty quit. If both fields are empty, go on (useful for backup of single tables without changing)
-		if ( '' === $search && '' === $replace ) {
+		if ( '' === $search && '' !== $replace ) {
 			$this->add_error( esc_attr__( 'Search field is empty.', 'search-and-replace' ) );
 
 			return FALSE;

--- a/inc/templates/search_replace.php
+++ b/inc/templates/search_replace.php
@@ -21,7 +21,7 @@ if ( ! defined( 'SEARCH_REPLACE_BASEDIR' ) ) {
 		</tr>
 		<tr>
 			<th><label for="csv"><strong>CSV Format Search/Replace (optional):</strong></label></th>
-			<td><textarea id="csv" cols="62" name="csv" placeholder="search value, replace value (one per line)"></textarea></td>
+			<td><textarea id="csv" cols="62" name="csv" placeholder="search value, replace value (one per line)"><?php $this->get_csv_value() ?></textarea></td>
 		</tr>
 		<tr>
 			<th><strong><?php esc_html_e( 'Select tables', 'search-and-replace' ); ?></strong></th>

--- a/inc/templates/search_replace.php
+++ b/inc/templates/search_replace.php
@@ -20,7 +20,7 @@ if ( ! defined( 'SEARCH_REPLACE_BASEDIR' ) ) {
 			<td><input id="replace" type="text" name="replace" value="<?php $this->get_replace_value() ?>" /></td>
 		</tr>
 		<tr>
-			<th><label for="csv"><strong>CSV Format Search/Replace (optional):</strong></label></th>
+			<th><label for="csv"><strong><?php esc_html_e( 'CSV Format Search/Replace:', 'search-and-replace'); ?></strong></label></th>
 			<td><textarea id="csv" cols="62" name="csv" placeholder="search value, replace value (one per line)"><?php $this->get_csv_value() ?></textarea></td>
 		</tr>
 		<tr>

--- a/inc/templates/search_replace.php
+++ b/inc/templates/search_replace.php
@@ -20,6 +20,10 @@ if ( ! defined( 'SEARCH_REPLACE_BASEDIR' ) ) {
 			<td><input id="replace" type="text" name="replace" value="<?php $this->get_replace_value() ?>" /></td>
 		</tr>
 		<tr>
+			<th><label for="csv"><strong>CSV Format Search/Replace (optional):</strong></label></th>
+			<td><textarea id="csv" cols="62" name="csv" placeholder="search value, replace value (one per line)"></textarea></td>
+		</tr>
+		<tr>
 			<th><strong><?php esc_html_e( 'Select tables', 'search-and-replace' ); ?></strong></th>
 			<td><?php $this->show_table_list(); ?><br>
 				<br><input id="select_all_tables" type="checkbox" name="select_all" />


### PR DESCRIPTION
I've found myself in need of a bulk search/replace function for some time now to handle broken links that occur when importing a site from HTML to Wordpress. To that end, I've added a CSV option to the Search & Replace tab. 

The CSV option's label is missing translations for German and Chinese.