### PR TITLE
Add error control operator before set_time_limit()

### DIFF
--- a/inc/Service/MaxExecutionTime.php
+++ b/inc/Service/MaxExecutionTime.php
@@ -24,7 +24,7 @@ class MaxExecutionTime {
 			$this->store();
 		}
 
-		set_time_limit( $time );
+		@set_time_limit( $time );
 
 	}
 


### PR DESCRIPTION
If `set_time_limit()` has been disabled for security reasons, and you have configured PHP to print warnings, the top of the `.sql`-dump file will include a PHP warning, not valid SQL.