### PR TITLE
Import: Fix alerts doesn't display.

### DIFF
--- a/inc/Page/AbstractPage.php
+++ b/inc/Page/AbstractPage.php
@@ -50,7 +50,11 @@ abstract class AbstractPage {
 
 		?>
 		<div class="error notice is-dismissible">
-			<?= sprintf( '<strong>%s</strong>', esc_html__( 'Errors:', 'search-and-replace' ) ); ?>
+			<p>
+				<strong>
+					<?php esc_html_e( 'Errors:', 'search-and-replace' ); ?>
+				</strong>
+			</p>
 			<ul>
 				<?php foreach ( $this->errors as $error ) : ?>
 					<li><?= esc_html( $error ); ?></li>

--- a/inc/Page/Manager.php
+++ b/inc/Page/Manager.php
@@ -103,7 +103,7 @@ class Manager {
 		$output = '<div class="wrap">';
 		$output .= '<h1 id="title">' . esc_html__( 'Search & Replace', 'search-and-replace' ) . '</h1>';
 		$output .= '<h2 class="nav-tab-wrapper">';
-		$page = '';
+
 		foreach ( $this->pages as $slug => $page ) :
 			$class = $current_page === $slug ? 'nav-tab-active' : '';
 			$output .= sprintf(
@@ -113,16 +113,19 @@ class Manager {
 				$page->get_page_title()
 			);
 		endforeach;
+		unset($page);
+
 		$output .= '</h2>';
+
+		// Set the current page.
+		$page = $this->pages[ $current_page ];
 
 		echo $output;
 		echo '<div class="tab__content">';
 		$this->save();
 		$page->display_errors();
-		$page = $this->pages[ $current_page ];
 		$page->render();
 		echo '</div>';
-
 		echo '</div>'; // wrap
 	}
 

--- a/inc/Page/SqlImport.php
+++ b/inc/Page/SqlImport.php
@@ -49,7 +49,7 @@ class SqlImport extends AbstractPage implements PageInterface {
 	 */
 	public function render() {
 
-		require_once( __DIR__ . '/../templates/sql-import.php' );
+		require_once dirname(__DIR__) . '/templates/sql-import.php';
 	}
 
 	/**
@@ -57,7 +57,7 @@ class SqlImport extends AbstractPage implements PageInterface {
 	 */
 	protected function get_submit_button_title() {
 
-		return __( 'Import SQL file', 'search-and-replace' );
+		return esc_html__( 'Import SQL file', 'search-and-replace' );
 	}
 
 	/**
@@ -69,28 +69,25 @@ class SqlImport extends AbstractPage implements PageInterface {
 		// maybe like here: http://stackoverflow.com/questions/147821/loading-sql-files-from-within-php , answer by user 'gromo'
 		$php_upload_error_code = $_FILES[ 'file_to_upload' ][ 'error' ];
 		if ( 0 === $php_upload_error_code ) {
-
 			// get file extension
 			$ext = strrchr( $_FILES [ 'file_to_upload' ][ 'name' ], '.' );
 			// parse file
 			$tempfile = $_FILES [ 'file_to_upload' ][ 'tmp_name' ];
 			switch ( $ext ) {
 				case '.sql':
-					// @codingStandardsIgnoreStart
+					// @codingStandardsIgnoreLine
 					$sql_source = file_get_contents( $tempfile );
-					// @codingStandardsIgnoreEnd
 					break;
 				case '.gz':
 					$sql_source = $this->read_gzfile_into_string( $tempfile );
 					break;
 				default:
 					$this->add_error(
-						__(
-							'The file has neither \'.gz\' nor \'.sql\' Extension.  Import not possible.',
+						esc_html__(
+							'The file has neither \'.gz\' nor \'.sql\' Extension. Import not possible.',
 							'search-and-replace'
 						)
 					);
-
 					return;
 			}
 
@@ -98,7 +95,7 @@ class SqlImport extends AbstractPage implements PageInterface {
 			$success = $this->dbi->import_sql( $sql_source );
 			if ( - 1 === $success ) {
 				$this->add_error(
-					__(
+					esc_html__(
 						'The file does not seem to be a valid SQL file. Import not possible.',
 						'search-and-replace'
 					)
@@ -106,36 +103,54 @@ class SqlImport extends AbstractPage implements PageInterface {
 			} else {
 				echo '<div class="updated notice is-dismissible">';
 				echo '<p>';
-				sprintf(
-					__(
+				printf(
+					esc_html__(
 						'The SQL file was successfully imported. %s SQL queries were performed.',
 						'search-and-replace'
 					),
-					esc_html( $success )
+					$success
 				);
 				echo '</p></div>';
 			}
 		} else {
 			// show error
 			$php_upload_errors = array(
-				0 => 'There is no error, the file uploaded with success',
+				0 => esc_html__(
+					'There is no error, the file uploaded with success',
+					'search-and-replace'
+				),
 				1 => esc_html__(
-					'The uploaded file exceeds the upload_max_filesize directive in php.ini', 'search-and-replace'
+					'The uploaded file exceeds the upload_max_filesize directive in php.ini',
+					'search-and-replace'
 				),
 				2 => esc_html__(
 					'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form',
 					'search-and-replace'
 				),
-				3 => esc_html__( 'The uploaded file was only partially uploaded', 'search-and-replace' ),
-				4 => esc_html__( 'No file was uploaded.', 'search-and-replace' ),
-				6 => esc_html__( 'Missing a temporary folder.', 'search-and-replace' ),
-				7 => esc_html__( 'Failed to write file to disk.', 'search-and-replace' ),
-				8 => esc_html__( 'A PHP extension stopped the file upload.', 'search-and-replace' ),
+				3 => esc_html__(
+					'The uploaded file was only partially uploaded',
+					'search-and-replace'
+				),
+				4 => esc_html__(
+					'No file was uploaded.',
+					'search-and-replace'
+				),
+				6 => esc_html__(
+					'Missing a temporary folder.',
+					'search-and-replace'
+				),
+				7 => esc_html__(
+					'Failed to write file to disk.',
+					'search-and-replace' ),
+				8 => esc_html__(
+					'A PHP extension stopped the file upload.',
+					'search-and-replace'
+				),
 			);
 
 			$this->add_error(
-				printf(
-					__( 'Upload Error: %s', 'search-and-replace' ),
+				sprintf(
+					esc_html__( 'Upload Error: %s', 'search-and-replace' ),
 					$php_upload_errors[ $php_upload_error_code ]
 				)
 			);
@@ -198,7 +213,7 @@ class SqlImport extends AbstractPage implements PageInterface {
 		$size = preg_replace( '/[^0-9\.]/', '', $size );
 		if ( $unit ) {
 			// Find the position of the unit in the ordered string which is the power of magnitude to multiply a kilobyte by.
-			return round( $size * pow( 1024, stripos( 'bkmgtpezy', $unit[ 0 ] ) ) );
+			return round( $size * pow( 1024, stripos( 'bkmgtpezy', $unit[0] ) ) );
 		} else {
 			return round( $size );
 		}


### PR DESCRIPTION
Within the `Manager` the `display_errors` is called on the latest element 
extracted within the pages loop, so that page may not be the current page.
Previously the current page was set after the display_errors call.

Using `esc_html__` where needed and fixed incorrect usage of `sprintf`/`printf`.
