### PR TITLE
Update Replace.php

### DIFF
--- a/inc/Database/Replace.php
+++ b/inc/Database/Replace.php
@@ -260,7 +260,7 @@ class Replace {
 					continue;
 				}
 
-				if ( $update && ! empty( $where_sql ) ) {
+				if ( $update && ! empty( $where_sql ) && !empty( $update_sql ) ) {
 					// If there are changes to make, run the query.
 					$result = $this->dbm->update( $table, $update_sql, $where_sql );
 


### PR DESCRIPTION
I have noticed a repetitive warning in the www error log.
The warning is kind like the following : 

```
[15-May-2019 07:43:47 UTC] Erreur de la base de donnÃ©es WordPress 

You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 

'WHERE object_id = "30"' at line 1 pour la requÃªte UPDATE wp_217_yoast_seo_meta SET  WHERE object_id = "30" faite par 

require_once('wp-admin/admin.php'), 
do_action('toplevel_page_onpc-live'), 
WP_Hook->do_action, 
WP_Hook->apply_filters, 
call_user_func_array, 
ONPC_Live->onpc_live, 
Inpsyde\SearchReplace\Database\Replace->run_search_replace
Inpsyde\SearchReplace\Database\Replace->replace_values
Inpsyde\SearchReplace\Database\Manager->update
```

In this case it is a table relative to YOAST Seo and so there is nothing to update, so the variable $update_sql is empty