### PR TITLE
Fix multiline problem in CSV format

### DIFF
--- a/inc/Database/Replace.php
+++ b/inc/Database/Replace.php
@@ -226,7 +226,7 @@ class Replace {
 
 					// Run a search replace by CSV parameters if CSV input present
 					if ( null !== $csv ) {
-                        $csvDataToFix = $data_to_fix;
+						$csvDataToFix = $data_to_fix;
 						foreach ( $this->csv_data as $entry ) {
 							$edited_data = is_serialized( $edited_data, false ) ?
 								$this->recursive_unserialize_replace(
@@ -234,9 +234,9 @@ class Replace {
 									$entry['replace'],
 									$edited_data
 								) : str_replace( $entry['search'], $entry['replace'], $csvDataToFix );
-                            $csvDataToFix = $edited_data;
+							$csvDataToFix = $edited_data;
 						}
-                        unset($csvDataToFix);
+						unset($csvDataToFix);
 					}
 
 					// Something was changed.

--- a/inc/Database/Replace.php
+++ b/inc/Database/Replace.php
@@ -226,13 +226,15 @@ class Replace {
 
 					// Run a search replace by CSV parameters if CSV input present
 					if ( null !== $csv ) {
+                        $csvDataToFix = $data_to_fix;
 						foreach ( $this->csv_data as $entry ) {
 							$edited_data = is_serialized( $edited_data, false ) ?
 								$this->recursive_unserialize_replace(
 									$entry['search'],
 									$entry['replace'],
 									$edited_data
-								) : str_replace( $entry['search'], $entry['replace'], $data_to_fix );
+								) : str_replace( $entry['search'], $entry['replace'], $csvDataToFix );
+                            $csvDataToFix = $edited_data;
 						}
 					}
 

--- a/inc/Database/Replace.php
+++ b/inc/Database/Replace.php
@@ -236,6 +236,7 @@ class Replace {
 								) : str_replace( $entry['search'], $entry['replace'], $csvDataToFix );
                             $csvDataToFix = $edited_data;
 						}
+                        unset($csvDataToFix);
 					}
 
 					// Something was changed.


### PR DESCRIPTION
Multiline search was working only for the last line when using the CSV format to run the search. 