### PR TITLE
Use unserialize in a custom method with allowed_classes set to false

### DIFF
--- a/inc/Database/Replace.php
+++ b/inc/Database/Replace.php
@@ -335,7 +335,7 @@ class Replace {
 
 		// Some unserialized data cannot be re-serialised eg. SimpleXMLElements.
 		try {
-			$unserialized = is_serialized( $data, false ) ? maybe_unserialize( $data ) : false;
+			$unserialized = is_serialized( $data, false ) ? $this->maybe_unserialize_safe( $data ) : false;
 
 			if ( $unserialized !== false && ! is_serialized_string( $data ) ) {
 				$data = $this->recursive_unserialize_replace( $from, $to, $unserialized, false );
@@ -369,7 +369,7 @@ class Replace {
 
 				if ( is_serialized_string( $data ) ) {
 					// @codingStandardsIgnoreLine
-					$data   = maybe_unserialize( $data );
+					$data   = $this->maybe_unserialize_safe( $data );
 					$marker = true;
 				}
 
@@ -427,5 +427,23 @@ class Replace {
 		}
 
 		return $state;
+	}
+
+	/**
+	 * Unserializes data only if it was serialized.
+	 * unserialize function is called with allowed_classes set to false
+	 * to ensure no object instantiation and magic function calls.
+	 *
+	 * @since 3.2.3
+	 *
+	 * @param string $data Data that might be unserialized.
+	 * @return mixed Unserialized data can be any type.
+	 */
+	public function maybe_unserialize_safe( $data ) {
+		if ( is_serialized( $data ) ) {
+			return @unserialize( trim( $data ), array('allowed_classes' => false ) );
+		}
+	
+		return $data;
 	}
 }

--- a/inc/Database/Replace.php
+++ b/inc/Database/Replace.php
@@ -348,7 +348,7 @@ class Replace {
 				$data = $_tmp;
 
 				unset( $_tmp );
-			} elseif ( is_object( $data ) ) {
+			} elseif ( 'object' == gettype( $data ) ) {
 				if ( $this->is_cloneable( $data ) ) {
 					$_tmp  = clone $data;
 					$props = get_object_vars( $data );

--- a/inpsyde-search-replace.php
+++ b/inpsyde-search-replace.php
@@ -7,7 +7,7 @@
  * Author:		 WP MEDIA SAS
  * Author URI:	 https://wp-media.me/
  * Contributors: s-hinse, derpixler, ChriCo, Bueltge, inpsyde
- * Version:      3.2.2
+ * Version:      3.2.3
  * Text Domain:  search-and-replace
  * Domain Path:  /languages
  * License:      GPLv2+

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: search, replace, import, sql, migrate,
 Requires at least: 4.0
 Tested up to: 6.5
 Requires PHP: 5.6
-Stable tag: 3.2.2
+Stable tag: 3.2.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,9 @@ You want to donate - we prefer a [positive review](https://wordpress.org/support
 5. Result screen after search or search and replace
 
 == Changelog ==
+= 3.2.3 (2024-08-22) =
+* Fixed a vulnerability when deserializing objects from the database
+
 = 3.2.2 (2024-05-16) =
 * Now owned by WP Media
 * Fixed potential time based SQL injection

--- a/tests/UnitTests/AbstractTestCase.php
+++ b/tests/UnitTests/AbstractTestCase.php
@@ -142,13 +142,4 @@ abstract class AbstractTestCase extends TestCase {
 
 		return $data;
 	}
-
-	public function maybe_unserialize( $data ) {
-
-		if ( is_serialized( $data ) ) {
-			return @unserialize( $data );
-		}
-
-		return $data;
-	}
 }

--- a/tests/UnitTests/Database/ReplaceTest.php
+++ b/tests/UnitTests/Database/ReplaceTest.php
@@ -316,9 +316,6 @@ class ReplaceTest extends AbstractTestCase {
 		\Brain\Monkey\Functions\when( 'maybe_serialize' )
 			->alias( [ $this, 'maybe_serialize' ] );
 
-		\Brain\Monkey\Functions\when( 'maybe_unserialize' )
-			->alias( [ $this, 'maybe_unserialize' ] );
-
 		$dbm_mock = \Mockery::mock(
 			'\Inpsyde\SearchReplace\Database\Manager',
 			[ \Mockery::mock( '\wpdb' ) ]
@@ -362,9 +359,6 @@ class ReplaceTest extends AbstractTestCase {
 
 		\Brain\Monkey\Functions\when( 'maybe_serialize' )
 			->alias( [ $this, 'maybe_serialize' ] );
-
-		\Brain\Monkey\Functions\when( 'maybe_unserialize' )
-			->alias( [ $this, 'maybe_unserialize' ] );
 
 		$manager_mock       = \Mockery::mock( 'Inpsyde\\SearchReplace\\Database\\Manager' );
 		$max_exec_time_mock = \Mockery::mock( 'Inpsyde\\SearchReplace\\Service\\MaxExecutionTime' );


### PR DESCRIPTION
bump version 3.2.3
Use unserialize in a custom method with allowed_classes set to false.
See Slack for more details

# Description

Fixes #144 

## Documentation

### User documentation

NA

### Technical documentation

Calls to unserialize($data) now have the allowed_classes option set to false to avoid the instanciation of objects and calls to magic methods.
Since unserialize was not directly access, but a function from WP instead (maybe_unserialize), I copy/pasted the code from WordPress and added the allowed_classes option

## Type of change
*Delete options that are not relevant.*

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).

## New dependencies
NA

## Risks
NA
